### PR TITLE
fix: Resolve 409 conflict errors by handling existing records on the server and marking them as synced locally

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -17,9 +17,10 @@ const SignIn = observer(() => {
   const handleSignIn = async () => {
     if (!email.trim() || !password.trim()) return;
 
+    authModel.actions.clearError();
     const result = await authModel.actions.signIn(email.trim(), password);
     if (result.success) {
-      router.replace("/");
+      router.replace("/setup");
     }
   };
 
@@ -88,15 +89,6 @@ const SignIn = observer(() => {
             </Pressable>
           </Link>
         </View>
-
-        <Pressable
-          onPress={() => router.replace("/(tabs)" as const as "/")}
-          className="mt-4"
-        >
-          <Text className="text-muted-foreground text-center text-sm">
-            Skip for now
-          </Text>
-        </Pressable>
       </View>
     </KeyboardAvoidingView>
   );

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -34,6 +34,7 @@ const SignUp = observer(() => {
       return;
     }
 
+    authModel.actions.clearError();
     const result = await authModel.actions.signUp(email.trim(), password);
     if (result.success) {
       if (result.needsConfirmation) {
@@ -43,7 +44,7 @@ const SignUp = observer(() => {
           [{ text: "OK", onPress: () => router.replace("/(auth)/sign-in") }],
         );
       } else {
-        router.replace("/(tabs)" as const as "/");
+        router.replace("/setup");
       }
     }
   };
@@ -132,15 +133,6 @@ const SignUp = observer(() => {
             </Pressable>
           </Link>
         </View>
-
-        <Pressable
-          onPress={() => router.replace("/(tabs)" as const as "/")}
-          className="mt-4"
-        >
-          <Text className="text-muted-foreground text-center text-sm">
-            Skip for now
-          </Text>
-        </Pressable>
       </View>
     </KeyboardAvoidingView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@ import { Splash } from "@/src/Components/Splash";
 import { rootStore } from "@/src/LegendState";
 import { appModel } from "@/src/LegendState/AppState/App.model";
 import { authModel } from "@/src/LegendState/Auth/Auth.model";
+import { setupModel } from "@/src/LegendState/Setup/Setup.model";
 import { themeModel } from "@/src/LegendState/Theme/Theme.model";
 import { RootProvider } from "@/src/Providers/RootProvider";
 import { analytics } from "@/src/services/analytics";
@@ -42,17 +43,32 @@ const useProtectedRoute = () => {
   const router = useRouter();
   const isAuthenticated = authModel.obs.isAuthenticated.get();
   const isAuthLoading = authModel.obs.isLoading.get();
+  const setupStatus = setupModel.obs.status.get();
 
   useEffect(() => {
     if (isAuthLoading) return;
 
     const inAuthGroup = segments[0] === "(auth)";
+    const inSetupRoute = String(segments[0]) === "setup";
 
-    // If user just signed in and is still on auth screens, redirect to app
-    if (isAuthenticated && inAuthGroup) {
-      router.replace("/(tabs)" as const as "/");
+    if (!isAuthenticated) {
+      if (!inAuthGroup) {
+        router.replace("/(auth)/sign-in");
+      }
+      return;
     }
-  }, [isAuthenticated, isAuthLoading, segments, router]);
+
+    if (setupStatus !== "success") {
+      if (!inSetupRoute) {
+        router.replace("/setup");
+      }
+      return;
+    }
+
+    if (inAuthGroup || inSetupRoute) {
+      router.replace("/" as const);
+    }
+  }, [isAuthenticated, isAuthLoading, router, segments, setupStatus]);
 };
 
 const RootLayoutNav = observer(() => {
@@ -63,6 +79,7 @@ const RootLayoutNav = observer(() => {
       <Stack screenOptions={{ statusBarStyle: "auto" }}>
         <Stack.Screen name="index" options={{ headerShown: false }} />
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+        <Stack.Screen name="setup/index" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen
           name="add-category/index"

--- a/app/setup/index.tsx
+++ b/app/setup/index.tsx
@@ -103,10 +103,7 @@ const SetupScreen = observer(() => {
       </View>
 
       {!isRunning && (
-        <Pressable
-          onPress={() => authModel.actions.signOut()}
-          className="mt-4"
-        >
+        <Pressable onPress={() => authModel.actions.signOut()} className="mt-4">
           <Text className="text-center text-muted-foreground text-sm">
             Use another account
           </Text>

--- a/app/setup/index.tsx
+++ b/app/setup/index.tsx
@@ -1,0 +1,119 @@
+import { observer } from "@legendapp/state/react";
+import { router } from "expo-router";
+import { useEffect } from "react";
+import { Pressable, View } from "react-native";
+
+import { Button } from "@/src/Components/ui/Button";
+import { Text } from "@/src/Components/ui/Text";
+import { authModel } from "@/src/LegendState/Auth/Auth.model";
+import { setupModel } from "@/src/LegendState/Setup/Setup.model";
+
+const STEP_LABELS: Record<string, string> = {
+  idle: "Preparing your account",
+  "connecting-account": "Connecting your account",
+  "syncing-data": "Syncing your data",
+  "checking-data": "Checking existing data",
+  "creating-defaults": "Creating defaults",
+  finishing: "Finishing setup",
+};
+
+const SetupScreen = observer(() => {
+  const isAuthenticated = authModel.obs.isAuthenticated.get();
+  const setupStatus = setupModel.obs.status.get();
+  const setupStep = setupModel.obs.step.get();
+  const setupError = setupModel.obs.error.get();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.replace("/(auth)/sign-in");
+      return;
+    }
+
+    if (setupStatus === "needsSetup") {
+      setupModel.actions.run().then((result) => {
+        if (result.success) {
+          router.replace("/(tabs)" as const as "/");
+        }
+      });
+      return;
+    }
+
+    if (setupStatus === "success") {
+      router.replace("/(tabs)/transactions");
+    }
+  }, [isAuthenticated, setupStatus]);
+
+  const retrySetup = async () => {
+    setupModel.actions.clearError();
+    const result = await setupModel.actions.run();
+    if (result.success) {
+      router.replace("/(tabs)/transactions");
+    }
+  };
+
+  const isRunning = setupStatus === "running" || setupStatus === "needsSetup";
+  const currentStep = STEP_LABELS[setupStep] ?? STEP_LABELS.idle;
+
+  return (
+    <View className="flex-1 bg-background px-6 justify-center">
+      <View className="bg-card rounded-2xl p-6 gap-4">
+        <View className="gap-2">
+          <Text className="text-2xl font-bold text-center">
+            Setting things up
+          </Text>
+          <Text className="text-center text-muted-foreground">
+            {isRunning
+              ? "We are getting your account ready before you enter the app."
+              : "Setup could not finish. Retry to continue into the app."}
+          </Text>
+        </View>
+
+        <View className="bg-muted rounded-xl p-4">
+          <Text className="text-sm text-muted-foreground text-center">
+            Current step
+          </Text>
+          <Text className="text-base font-medium text-center mt-1">
+            {currentStep}
+          </Text>
+        </View>
+
+        {setupError && (
+          <View className="bg-destructive/10 rounded-xl p-4">
+            <Text className="text-destructive text-center text-sm">
+              {setupError}
+            </Text>
+          </View>
+        )}
+
+        {isRunning ? (
+          <Text className="text-center text-sm text-muted-foreground">
+            Please keep the app open while setup completes.
+          </Text>
+        ) : (
+          <View className="gap-3">
+            <Button onPress={retrySetup}>Retry Setup</Button>
+            <Button
+              variant="outline"
+              onPress={() => authModel.actions.signOut()}
+            >
+              Sign Out
+            </Button>
+          </View>
+        )}
+      </View>
+
+      {!isRunning && (
+        <Pressable
+          onPress={() => authModel.actions.signOut()}
+          className="mt-4"
+        >
+          <Text className="text-center text-muted-foreground text-sm">
+            Use another account
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+});
+
+export default SetupScreen;

--- a/db/client.ts
+++ b/db/client.ts
@@ -4,3 +4,26 @@ import { openDatabaseSync } from "expo-sqlite";
 export const COINX_DATABASE_NAME = "coinx.db";
 export const expoDb = openDatabaseSync(COINX_DATABASE_NAME);
 export const db = drizzle(expoDb);
+
+/**
+ * Wipe all user-generated local data while preserving schema and migrations.
+ * Child tables are deleted first to satisfy foreign-key constraints.
+ */
+export async function clearLocalDatabase(): Promise<void> {
+  await expoDb.execAsync("BEGIN TRANSACTION;");
+
+  try {
+    await expoDb.execAsync(`
+      DELETE FROM coinx_product_listing_history;
+      DELETE FROM coinx_product_listing;
+      DELETE FROM coinx_transaction;
+      DELETE FROM coinx_store;
+      DELETE FROM coinx_product;
+      DELETE FROM coinx_category;
+    `);
+    await expoDb.execAsync("COMMIT;");
+  } catch (error) {
+    await expoDb.execAsync("ROLLBACK;");
+    throw error;
+  }
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -17,9 +17,9 @@ export type SyncStatus = (typeof syncStatusEnum)[number];
 
 export const categories = sqliteTable("coinx_category", {
   id: text("id").primaryKey(), // UUID
-  name: text("name").notNull().unique(),
-  icon: text("icon").notNull().unique(),
-  color: text("color").notNull().unique(),
+  name: text("name").notNull(),
+  icon: text("icon").notNull(),
+  color: text("color").notNull(),
   type: text("type", { enum: ["Income", "Expense"] }).notNull(),
 
   createdAt: text("created_at")
@@ -96,32 +96,21 @@ export const productsRelations = relations(products, ({ many }) => ({
 
 // ─── Stores ──────────────────────────────────────────────────
 
-export const stores = sqliteTable(
-  "coinx_store",
-  {
-    id: text("id").primaryKey(), // UUID
-    name: text("name").notNull(),
-    location: text("location"),
+export const stores = sqliteTable("coinx_store", {
+  id: text("id").primaryKey(), // UUID
+  name: text("name").notNull(),
+  location: text("location"),
 
-    createdAt: text("created_at")
-      .default(sql`CURRENT_TIMESTAMP`)
-      .notNull(),
-    updatedAt: text("updated_at"),
+  createdAt: text("created_at")
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+  updatedAt: text("updated_at"),
 
-    // Sync fields
-    syncStatus: text("sync_status", { enum: syncStatusEnum }).default(
-      "pending",
-    ),
-    deletedAt: text("deleted_at"),
-    localOwnerId: text("local_owner_id"),
-  },
-  (table) => ({
-    uniqueNameAndLocation: unique("unique_store_name_location").on(
-      table.name,
-      table.location,
-    ),
-  }),
-);
+  // Sync fields
+  syncStatus: text("sync_status", { enum: syncStatusEnum }).default("pending"),
+  deletedAt: text("deleted_at"),
+  localOwnerId: text("local_owner_id"),
+});
 
 export const storesRelations = relations(stores, ({ many }) => ({
   product_listings: many(product_listings),

--- a/drizzle/0003_typical_blonde_phantom.sql
+++ b/drizzle/0003_typical_blonde_phantom.sql
@@ -1,0 +1,3 @@
+DROP INDEX `coinx_category_name_unique`;--> statement-breakpoint
+DROP INDEX `coinx_category_icon_unique`;--> statement-breakpoint
+DROP INDEX `coinx_category_color_unique`;

--- a/drizzle/0004_silent_dagger.sql
+++ b/drizzle/0004_silent_dagger.sql
@@ -1,0 +1,1 @@
+DROP INDEX `unique_store_name_location`;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,631 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "661479ce-9f0a-46c9-be9f-670bb05a7011",
+  "prevId": "530a4296-922d-496c-9eae-c6df29457876",
+  "tables": {
+    "coinx_category": {
+      "name": "coinx_category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product_listing": {
+      "name": "coinx_product_listing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_listings_product_id": {
+          "name": "idx_product_listings_product_id",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_store_id": {
+          "name": "idx_product_listings_store_id",
+          "columns": [
+            "store_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coinx_product_listing_product_id_coinx_product_id_fk": {
+          "name": "coinx_product_listing_product_id_coinx_product_id_fk",
+          "tableFrom": "coinx_product_listing",
+          "tableTo": "coinx_product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coinx_product_listing_store_id_coinx_store_id_fk": {
+          "name": "coinx_product_listing_store_id_coinx_store_id_fk",
+          "tableFrom": "coinx_product_listing",
+          "tableTo": "coinx_store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product_listing_history": {
+      "name": "coinx_product_listing_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_listing_id": {
+          "name": "product_listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_listings_history_product_id": {
+          "name": "idx_product_listings_history_product_id",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_history_product_listing_id": {
+          "name": "idx_product_listings_history_product_listing_id",
+          "columns": [
+            "product_listing_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_history_recorded_at": {
+          "name": "idx_product_listings_history_recorded_at",
+          "columns": [
+            "recorded_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coinx_product_listing_history_product_id_coinx_product_id_fk": {
+          "name": "coinx_product_listing_history_product_id_coinx_product_id_fk",
+          "tableFrom": "coinx_product_listing_history",
+          "tableTo": "coinx_product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coinx_product_listing_history_product_listing_id_coinx_product_listing_id_fk": {
+          "name": "coinx_product_listing_history_product_listing_id_coinx_product_listing_id_fk",
+          "tableFrom": "coinx_product_listing_history",
+          "tableTo": "coinx_product_listing",
+          "columnsFrom": [
+            "product_listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product": {
+      "name": "coinx_product",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_unit_category": {
+          "name": "default_unit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_store": {
+      "name": "coinx_store",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_store_name_location": {
+          "name": "unique_store_name_location",
+          "columns": [
+            "name",
+            "location"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_transaction": {
+      "name": "coinx_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_time": {
+          "name": "transaction_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coinx_transaction_category_id_coinx_category_id_fk": {
+          "name": "coinx_transaction_category_id_coinx_category_id_fk",
+          "tableFrom": "coinx_transaction",
+          "tableTo": "coinx_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,622 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "15b4978c-ee6a-45b2-afcb-41d8928620e3",
+  "prevId": "661479ce-9f0a-46c9-be9f-670bb05a7011",
+  "tables": {
+    "coinx_category": {
+      "name": "coinx_category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product_listing": {
+      "name": "coinx_product_listing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_listings_product_id": {
+          "name": "idx_product_listings_product_id",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_store_id": {
+          "name": "idx_product_listings_store_id",
+          "columns": [
+            "store_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coinx_product_listing_product_id_coinx_product_id_fk": {
+          "name": "coinx_product_listing_product_id_coinx_product_id_fk",
+          "tableFrom": "coinx_product_listing",
+          "tableTo": "coinx_product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coinx_product_listing_store_id_coinx_store_id_fk": {
+          "name": "coinx_product_listing_store_id_coinx_store_id_fk",
+          "tableFrom": "coinx_product_listing",
+          "tableTo": "coinx_store",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product_listing_history": {
+      "name": "coinx_product_listing_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_listing_id": {
+          "name": "product_listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_listings_history_product_id": {
+          "name": "idx_product_listings_history_product_id",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_history_product_listing_id": {
+          "name": "idx_product_listings_history_product_listing_id",
+          "columns": [
+            "product_listing_id"
+          ],
+          "isUnique": false
+        },
+        "idx_product_listings_history_recorded_at": {
+          "name": "idx_product_listings_history_recorded_at",
+          "columns": [
+            "recorded_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coinx_product_listing_history_product_id_coinx_product_id_fk": {
+          "name": "coinx_product_listing_history_product_id_coinx_product_id_fk",
+          "tableFrom": "coinx_product_listing_history",
+          "tableTo": "coinx_product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coinx_product_listing_history_product_listing_id_coinx_product_listing_id_fk": {
+          "name": "coinx_product_listing_history_product_listing_id_coinx_product_listing_id_fk",
+          "tableFrom": "coinx_product_listing_history",
+          "tableTo": "coinx_product_listing",
+          "columnsFrom": [
+            "product_listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_product": {
+      "name": "coinx_product",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_unit_category": {
+          "name": "default_unit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_store": {
+      "name": "coinx_store",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coinx_transaction": {
+      "name": "coinx_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_time": {
+          "name": "transaction_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_owner_id": {
+          "name": "local_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coinx_transaction_category_id_coinx_category_id_fk": {
+          "name": "coinx_transaction_category_id_coinx_category_id_fk",
+          "tableFrom": "coinx_transaction",
+          "tableTo": "coinx_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1771301182626,
       "tag": "0002_stale_lester",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1772910525699,
+      "tag": "0003_typical_blonde_phantom",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1772911900976,
+      "tag": "0004_silent_dagger",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -4,12 +4,17 @@ import journal from './meta/_journal.json';
 import m0000 from './0000_flashy_morlocks.sql';
 import m0001 from './0001_flaky_senator_kelly.sql';
 import m0002 from './0002_stale_lester.sql';
+import m0003 from './0003_typical_blonde_phantom.sql';
+import m0004 from './0004_silent_dagger.sql';
 
   export default {
     journal,
     migrations: {
       m0000,
 m0001,
-m0002
+m0002,
+m0003,
+m0004
     }
   }
+  

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "main": "./index",
   "scripts": {
-   "android": "expo run:android",
-    "generate": "drizzle-kit generate",
-    "ios": "expo run:ios",
-    "lint": "oxlint",
-    "format": "oxfmt",
-    "postinstall": "patch-package",
     "start": "expo start",
-    "type-check": "tsc  --noemit",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
-    "prepare": "lefthook install"
+    "prebuild": "expo prebuild",
+    "db:generate": "drizzle-kit generate",
+    "postinstall": "patch-package",
+    "prepare": "lefthook install",
+    "type-check": "tsc  --noemit",
+    "lint": "oxlint",
+    "format": "oxfmt"
   },
   "dependencies": {
     "@coinify/currency": "^1.4.2",

--- a/src/LegendState/Auth/Auth.model.ts
+++ b/src/LegendState/Auth/Auth.model.ts
@@ -3,8 +3,8 @@ import type { Session, User } from "@supabase/supabase-js";
 import { observable } from "@legendapp/state";
 import { Effect } from "effect";
 
-import { analytics } from "@/src/services/analytics";
 import { setupModel } from "@/src/LegendState/Setup/Setup.model";
+import { analytics } from "@/src/services/analytics";
 import { supabase } from "@/src/services/supabase";
 import { syncManager } from "@/src/services/sync";
 

--- a/src/LegendState/Auth/Auth.model.ts
+++ b/src/LegendState/Auth/Auth.model.ts
@@ -3,6 +3,7 @@ import type { Session, User } from "@supabase/supabase-js";
 import { observable } from "@legendapp/state";
 import { Effect } from "effect";
 
+import { clearLocalDatabase } from "@/db/client";
 import { setupModel } from "@/src/LegendState/Setup/Setup.model";
 import { analytics } from "@/src/services/analytics";
 import { supabase } from "@/src/services/supabase";
@@ -44,7 +45,7 @@ export class AuthModel {
         this.obs.user.set(session.user);
         this.obs.session.set(session);
         this.obs.isAuthenticated.set(true);
-        setupModel.actions.reset("needsSetup");
+        setupModel.actions.reset(setupModel.getStatusForUser(session.user.id));
       }
     } catch (error) {
       console.error("Auth initialization error:", error);
@@ -61,7 +62,7 @@ export class AuthModel {
       if (event === "SIGNED_OUT" || !session) {
         setupModel.actions.reset("idle");
       } else if (event === "SIGNED_IN" || event === "INITIAL_SESSION") {
-        setupModel.actions.reset("needsSetup");
+        setupModel.actions.reset(setupModel.getStatusForUser(session.user.id));
       }
 
       try {
@@ -142,6 +143,8 @@ export class AuthModel {
     this.obs.isLoading.set(true);
     try {
       await supabase.auth.signOut();
+      await clearLocalDatabase();
+      setupModel.actions.clearPersistedCompletion();
       await Effect.runPromise(syncManager.reset());
     } catch (error) {
       console.error("Sign out error:", error);

--- a/src/LegendState/Auth/Auth.model.ts
+++ b/src/LegendState/Auth/Auth.model.ts
@@ -4,10 +4,9 @@ import { observable } from "@legendapp/state";
 import { Effect } from "effect";
 
 import { analytics } from "@/src/services/analytics";
-import { api } from "@/src/services/api";
+import { setupModel } from "@/src/LegendState/Setup/Setup.model";
 import { supabase } from "@/src/services/supabase";
 import { syncManager } from "@/src/services/sync";
-import { claimAnonymousData } from "@/src/services/sync/migration";
 
 type AuthState = {
   user: User | null;
@@ -45,6 +44,7 @@ export class AuthModel {
         this.obs.user.set(session.user);
         this.obs.session.set(session);
         this.obs.isAuthenticated.set(true);
+        setupModel.actions.reset("needsSetup");
       }
     } catch (error) {
       console.error("Auth initialization error:", error);
@@ -53,10 +53,16 @@ export class AuthModel {
     }
 
     // Listen for auth state changes (sign in, sign out, token refresh)
-    supabase.auth.onAuthStateChange((_event, session) => {
+    supabase.auth.onAuthStateChange((event, session) => {
       this.obs.session.set(session);
       this.obs.user.set(session?.user ?? null);
       this.obs.isAuthenticated.set(!!session);
+
+      if (event === "SIGNED_OUT" || !session) {
+        setupModel.actions.reset("idle");
+      } else if (event === "SIGNED_IN" || event === "INITIAL_SESSION") {
+        setupModel.actions.reset("needsSetup");
+      }
 
       try {
         if (session?.user?.id) {
@@ -89,26 +95,6 @@ export class AuthModel {
         return { success: false, error: error.message };
       }
 
-      // Register profile on backend
-      if (data.session) {
-        const userId = data.session.user.id;
-
-        // Claim any anonymous local data for this user before syncing
-        await Effect.runPromise(claimAnonymousData(userId)).catch(() => {
-          console.warn("Failed to claim anonymous data on sign up");
-        });
-
-        try {
-          await api.post("/api/auth/register");
-        } catch (e) {
-          console.warn("Backend profile registration failed:", e);
-          // Don't block auth — backend profile can be created later
-        }
-
-        // Trigger initial sync after sign up (will push newly claimed records)
-        syncManager.syncIfAuthenticated();
-      }
-
       return { success: true, needsConfirmation: !data.session };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Sign up failed";
@@ -136,25 +122,6 @@ export class AuthModel {
       if (error) {
         this.obs.error.set(error.message);
         return { success: false, error: error.message };
-      }
-
-      if (data.session) {
-        const userId = data.session.user.id;
-
-        // Claim any anonymous local data for this user before syncing
-        await Effect.runPromise(claimAnonymousData(userId)).catch(() => {
-          console.warn("Failed to claim anonymous data on sign in");
-        });
-
-        // Ensure profile exists on backend
-        try {
-          await api.post("/api/auth/register");
-        } catch (e) {
-          console.warn("Backend profile registration failed:", e);
-        }
-
-        // Trigger sync after sign in (will push newly claimed records)
-        syncManager.syncIfAuthenticated();
       }
 
       return { success: true };
@@ -189,7 +156,6 @@ export class AuthModel {
   clearError = () => {
     this.obs.error.set(null);
   };
-
   actions = {
     initialize: this.initialize,
     signUp: this.signUp,

--- a/src/LegendState/Category.model.ts
+++ b/src/LegendState/Category.model.ts
@@ -11,7 +11,7 @@ import { db as database } from "@/db/client";
 import { categories as categoriesRepo } from "@/db/schema";
 import { generateUUID } from "@/src/utils/uuid";
 
-const DEFAULT_CATEGORIES = [
+export const DEFAULT_CATEGORIES = [
   {
     name: "Food",
     color: "#FFC542",

--- a/src/LegendState/Setup/Setup.model.ts
+++ b/src/LegendState/Setup/Setup.model.ts
@@ -124,7 +124,7 @@ export class SetupModel {
 
       try {
         this.setStep("connecting-account");
-        await api.post("/api/auth/register");
+        await api.post("/api/auth/register", {});
 
         this.setStep("syncing-data");
         await syncManager.syncAuthenticated();

--- a/src/LegendState/Setup/Setup.model.ts
+++ b/src/LegendState/Setup/Setup.model.ts
@@ -1,0 +1,172 @@
+import { observable } from "@legendapp/state";
+import { isNull } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { categories, products, stores } from "@/db/schema";
+import { DEFAULT_CATEGORIES } from "@/src/LegendState/Category.model";
+import { DEFAULT_PRODUCTS } from "@/src/LegendState/Products/DefaultProducts";
+import { DEFAULT_STORES } from "@/src/LegendState/Store/stores-list";
+import { api } from "@/src/services/api";
+import { syncManager } from "@/src/services/sync";
+import { generateUUID } from "@/src/utils/uuid";
+
+export type SetupStatus =
+  | "idle"
+  | "needsSetup"
+  | "running"
+  | "success"
+  | "error";
+
+export type SetupStep =
+  | "idle"
+  | "connecting-account"
+  | "syncing-data"
+  | "checking-data"
+  | "creating-defaults"
+  | "finishing";
+
+type SetupState = {
+  status: SetupStatus;
+  step: SetupStep;
+  error: string | null;
+};
+
+export class SetupModel {
+  obs;
+
+  constructor() {
+    this.obs = observable<SetupState>({
+      status: "idle",
+      step: "idle",
+      error: null,
+    });
+  }
+
+  private setupPromise: Promise<{ success: boolean; error?: string }> | null =
+    null;
+
+  private getSeedCounts = async () => {
+    const [categoryRows, productRows, storeRows] = await Promise.all([
+      db
+        .select({ id: categories.id })
+        .from(categories)
+        .where(isNull(categories.deletedAt))
+        .limit(1),
+      db
+        .select({ id: products.id })
+        .from(products)
+        .where(isNull(products.deletedAt))
+        .limit(1),
+      db
+        .select({ id: stores.id })
+        .from(stores)
+        .where(isNull(stores.deletedAt))
+        .limit(1),
+    ]);
+
+    return {
+      hasCategories: categoryRows.length > 0,
+      hasProducts: productRows.length > 0,
+      hasStores: storeRows.length > 0,
+    };
+  };
+
+  private createDefaultSeedData = async () => {
+    await db.transaction(async (tx) => {
+      await tx.insert(categories).values(
+        DEFAULT_CATEGORIES.map((category) => ({
+          ...category,
+          id: generateUUID(),
+          syncStatus: "pending" as const,
+        })),
+      );
+
+      await tx.insert(products).values(
+        DEFAULT_PRODUCTS.map((product) => ({
+          ...product,
+          id: generateUUID(),
+          syncStatus: "pending" as const,
+        })),
+      );
+
+      await tx.insert(stores).values(
+        DEFAULT_STORES.map((store) => ({
+          ...store,
+          id: generateUUID(),
+          syncStatus: "pending" as const,
+        })),
+      );
+    });
+  };
+
+  private setStep = (step: SetupStep) => {
+    this.obs.step.set(step);
+  };
+
+  reset = (status: SetupStatus = "idle") => {
+    this.obs.status.set(status);
+    this.obs.step.set(status === "needsSetup" ? "connecting-account" : "idle");
+    this.obs.error.set(null);
+  };
+
+  clearError = () => {
+    this.obs.error.set(null);
+  };
+
+  run = async () => {
+    if (this.setupPromise) {
+      return this.setupPromise;
+    }
+
+    this.setupPromise = (async () => {
+      this.obs.status.set("running");
+      this.obs.error.set(null);
+
+      try {
+        this.setStep("connecting-account");
+        await api.post("/api/auth/register");
+
+        this.setStep("syncing-data");
+        await syncManager.syncAuthenticated();
+
+        this.setStep("checking-data");
+        const seedCounts = await this.getSeedCounts();
+        const needsSeedData =
+          !seedCounts.hasCategories &&
+          !seedCounts.hasProducts &&
+          !seedCounts.hasStores;
+
+        if (needsSeedData) {
+          this.setStep("creating-defaults");
+          await this.createDefaultSeedData();
+
+          this.setStep("finishing");
+          await syncManager.syncAuthenticated();
+        }
+
+        this.obs.status.set("success");
+        this.obs.step.set("idle");
+        this.obs.error.set(null);
+        return { success: true };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to finish setup";
+        this.obs.status.set("error");
+        this.obs.error.set(message);
+        return { success: false, error: message };
+      } finally {
+        this.setupPromise = null;
+      }
+    })();
+
+    return this.setupPromise;
+  };
+
+  actions = {
+    run: this.run,
+    reset: this.reset,
+    clearError: this.clearError,
+  };
+}
+
+export const setupModel = new SetupModel();

--- a/src/LegendState/Setup/Setup.model.ts
+++ b/src/LegendState/Setup/Setup.model.ts
@@ -7,6 +7,7 @@ import { DEFAULT_CATEGORIES } from "@/src/LegendState/Category.model";
 import { DEFAULT_PRODUCTS } from "@/src/LegendState/Products/DefaultProducts";
 import { DEFAULT_STORES } from "@/src/LegendState/Store/stores-list";
 import { api } from "@/src/services/api";
+import { AppStorage } from "@/src/storage/mmkv";
 import { syncManager } from "@/src/services/sync";
 import { generateUUID } from "@/src/utils/uuid";
 
@@ -44,6 +45,25 @@ export class SetupModel {
 
   private setupPromise: Promise<{ success: boolean; error?: string }> | null =
     null;
+
+  private getCompletionKey = (userId: string) => `setup_complete:${userId}`;
+
+  getStatusForUser = (userId: string): SetupStatus => {
+    const isComplete = AppStorage.getBoolean(this.getCompletionKey(userId));
+    return isComplete ? "success" : "needsSetup";
+  };
+
+  markCompleteForUser = (userId: string) => {
+    AppStorage.set(this.getCompletionKey(userId), true);
+  };
+
+  clearPersistedCompletion = () => {
+    for (const key of AppStorage.getAllKeys()) {
+      if (key.startsWith("setup_complete:")) {
+        AppStorage.delete(key);
+      }
+    }
+  };
 
   private getSeedCounts = async () => {
     const [categoryRows, productRows, storeRows] = await Promise.all([
@@ -147,6 +167,8 @@ export class SetupModel {
         this.obs.status.set("success");
         this.obs.step.set("idle");
         this.obs.error.set(null);
+        const currentUserId = await syncManager.getAuthenticatedUserId();
+        this.markCompleteForUser(currentUserId);
         return { success: true };
       } catch (error) {
         const message =
@@ -166,6 +188,7 @@ export class SetupModel {
     run: this.run,
     reset: this.reset,
     clearError: this.clearError,
+    clearPersistedCompletion: this.clearPersistedCompletion,
   };
 }
 

--- a/src/LegendState/Setup/Setup.model.ts
+++ b/src/LegendState/Setup/Setup.model.ts
@@ -7,8 +7,8 @@ import { DEFAULT_CATEGORIES } from "@/src/LegendState/Category.model";
 import { DEFAULT_PRODUCTS } from "@/src/LegendState/Products/DefaultProducts";
 import { DEFAULT_STORES } from "@/src/LegendState/Store/stores-list";
 import { api } from "@/src/services/api";
-import { AppStorage } from "@/src/storage/mmkv";
 import { syncManager } from "@/src/services/sync";
+import { AppStorage } from "@/src/storage/mmkv";
 import { generateUUID } from "@/src/utils/uuid";
 
 export type SetupStatus =

--- a/src/LegendState/index.ts
+++ b/src/LegendState/index.ts
@@ -60,16 +60,6 @@ class RootStore {
         Effect.catchAll(() => Effect.void),
       ),
     );
-
-    const isFirstLaunch = await appModel.checkFirstLaunch();
-    if (isFirstLaunch) {
-      await this.categoryModel.createDefaultCategories();
-      await this.productsModel.createDefaultProducts();
-      await storeModel$.createDefaultStores();
-    }
-
-    // Trigger initial sync if user is authenticated
-    syncManager.syncIfAuthenticated();
   };
 
   actions = {

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -15,7 +15,7 @@ export function useSync() {
 
   return {
     ...state,
-    sync: () => syncManager.syncIfAuthenticated(),
+    sync: () => syncManager.syncAuthenticated(),
     isSyncing: state.status === "pushing" || state.status === "pulling",
   };
 }

--- a/src/services/sync/database.ts
+++ b/src/services/sync/database.ts
@@ -95,25 +95,40 @@ export const applyTableChanges = (
         // Upsert records
         if (changeSet.upserted.length > 0) {
           for (const record of changeSet.upserted) {
-            const localRecord: Record<string, unknown> = { ...record };
-            // Convert string amounts back to numbers for local storage
-            if (typeof localRecord.amount === "string") {
-              const parsed = Number.parseFloat(localRecord.amount);
-              localRecord.amount = Number.isNaN(parsed) ? 0 : parsed;
-            }
-            if (typeof localRecord.price === "string") {
-              const parsed = Number.parseFloat(localRecord.price);
-              localRecord.price = Number.isNaN(parsed) ? 0 : parsed;
-            }
-            localRecord.syncStatus = "synced";
+            try {
+              const localRecord: Record<string, unknown> = { ...record };
+              // Convert string amounts back to numbers for local storage
+              if (typeof localRecord.amount === "string") {
+                const parsed = Number.parseFloat(localRecord.amount);
+                localRecord.amount = Number.isNaN(parsed) ? 0 : parsed;
+              }
+              if (typeof localRecord.price === "string") {
+                const parsed = Number.parseFloat(localRecord.price);
+                localRecord.price = Number.isNaN(parsed) ? 0 : parsed;
+              }
+              localRecord.syncStatus = "synced";
 
-            const { id, ...updatePayload } = localRecord;
+              const { id: _id, ...updatePayload } = localRecord;
 
-            await tx.insert(table).values(localRecord).onConflictDoUpdate({
-              target: idColumn,
-              set: updatePayload,
-            });
-            count++;
+              await tx.insert(table).values(localRecord).onConflictDoUpdate({
+                target: idColumn,
+                set: updatePayload,
+              });
+              count++;
+            } catch (recordError) {
+              console.error(
+                `[Database] Failed to upsert record with id ${record.id}:`,
+                {
+                  error:
+                    recordError instanceof Error
+                      ? recordError.message
+                      : String(recordError),
+                  recordId: record.id,
+                  tableName: (table as { name?: string }).name,
+                },
+              );
+              throw recordError; // Re-throw to fail the transaction
+            }
           }
         }
 
@@ -136,12 +151,25 @@ export const applyTableChanges = (
 
       return count;
     },
-    catch: (error) =>
-      new DatabaseError({
-        message: "Failed to apply table changes",
+    catch: (error) => {
+      // Log detailed error information for debugging
+      console.error("[Database] Failed to apply table changes:", {
+        error: error instanceof Error ? error.message : String(error),
+        tableName: (table as { name?: string }).name,
+        changeSetSize: {
+          upserted: changeSet.upserted.length,
+          deleted: changeSet.deleted.length,
+        },
+      });
+      if (error instanceof Error && error.stack) {
+        console.error("[Database] Stack trace:", error.stack);
+      }
+      return new DatabaseError({
+        message: `Failed to apply table changes: ${error instanceof Error ? error.message : String(error)}`,
         operation: "applyTableChanges",
         cause: error,
-      }),
+      });
+    },
   });
 
 /**
@@ -162,7 +190,11 @@ export function splitChanges(records: SyncableRecord[]): {
     if (record.deletedAt) {
       deleted.push(record.id);
     } else {
-      const { syncStatus, deletedAt, ...rest } = record;
+      const {
+        syncStatus: _syncStatus,
+        deletedAt: _deletedAt,
+        ...rest
+      } = record;
       // Convert amount/price from number to string for backend
       if (typeof rest.amount === "number") {
         rest.amount = String(rest.amount);

--- a/src/services/sync/manager.ts
+++ b/src/services/sync/manager.ts
@@ -167,7 +167,8 @@ export class SyncManager {
             ) {
               return Effect.fail(
                 new DeviceRegistrationError({
-                  message: "Failed to register device: invalid or missing ID in response",
+                  message:
+                    "Failed to register device: invalid or missing ID in response",
                 }),
               );
             }
@@ -193,7 +194,11 @@ export class SyncManager {
                 error instanceof Error
                   ? error.message
                   : "Device registration failed";
-              this.logStructuredError("device_registration", errorMessage, error);
+              this.logStructuredError(
+                "device_registration",
+                errorMessage,
+                error,
+              );
             }),
           ),
         );
@@ -342,14 +347,19 @@ export class SyncManager {
         Effect.sync(() => {
           const message =
             error instanceof Error ? error.message : "Sync failed";
-          
+
           if (!this.syncCancelled && !(error instanceof SyncCancelledError)) {
             this.lastSyncHadError = true;
             // Determine context based on current status
-            const context = this.state.status === "pushing" ? "push" : this.state.status === "pulling" ? "pull" : "sync";
+            const context =
+              this.state.status === "pushing"
+                ? "push"
+                : this.state.status === "pulling"
+                  ? "pull"
+                  : "sync";
             this.logStructuredError(context, message, error);
-            this.updateState({ 
-              status: "error", 
+            this.updateState({
+              status: "error",
               error: message,
               consecutiveFailures: this.state.consecutiveFailures + 1,
               lastErrorTimestamp: new Date().toISOString(),
@@ -517,7 +527,8 @@ export class SyncManager {
       }),
       Effect.tapError((error) =>
         Effect.sync(() => {
-          const errorMessage = error instanceof Error ? error.message : "Push failed";
+          const errorMessage =
+            error instanceof Error ? error.message : "Push failed";
           this.logStructuredError("push", errorMessage, error);
         }),
       ),
@@ -570,17 +581,23 @@ export class SyncManager {
       { table: products, ids: pushedIds.products },
       { table: stores, ids: pushedIds.stores },
       { table: product_listings, ids: pushedIds.product_listings },
-      { table: product_listings_history, ids: pushedIds.product_listings_history },
+      {
+        table: product_listings_history,
+        ids: pushedIds.product_listings_history,
+      },
     ] as const;
 
     // Map to effects, only processing tables with IDs
     const effects = tableOperations.map(({ table, ids }) =>
       ids.length > 0
         ? markRecordsSyncedForTable(table, ids)
-        : Effect.succeed(undefined)
+        : Effect.succeed(undefined),
     );
 
-    return pipe(Effect.all(effects), Effect.map(() => undefined));
+    return pipe(
+      Effect.all(effects),
+      Effect.map(() => undefined),
+    );
   };
 
   // ─── Pull ────────────────────────────────────────────────
@@ -623,7 +640,8 @@ export class SyncManager {
       }),
       Effect.tapError((error) =>
         Effect.sync(() => {
-          const errorMessage = error instanceof Error ? error.message : "Pull failed";
+          const errorMessage =
+            error instanceof Error ? error.message : "Pull failed";
           this.logStructuredError("pull", errorMessage, error);
         }),
       ),
@@ -795,7 +813,8 @@ export class SyncManager {
       ),
       Effect.catchAll((error) =>
         Effect.sync(() => {
-          const errorMessage = error instanceof Error ? error.message : "Reset failed";
+          const errorMessage =
+            error instanceof Error ? error.message : "Reset failed";
           this.logStructuredError("reset", errorMessage, error);
         }),
       ),

--- a/src/services/sync/manager.ts
+++ b/src/services/sync/manager.ts
@@ -9,6 +9,7 @@ import {
   stores,
   transactions,
 } from "@/db/schema";
+import { getHttpStatusFromError } from "@/src/utils/http";
 
 import type {
   PushedIds,
@@ -47,6 +48,9 @@ export class SyncManager {
     error: null,
     lastPushCount: 0,
     lastPullCount: 0,
+    consecutiveFailures: 0,
+    lastErrorTimestamp: null,
+    lastErrorContext: null,
   };
 
   private syncInProgress = false;
@@ -91,11 +95,15 @@ export class SyncManager {
       }),
       Effect.tapError((error) =>
         Effect.sync(() => {
-          console.error("Initialization error:", error);
+          const errorMessage =
+            error instanceof Error ? error.message : "Initialization failed";
+          this.logStructuredError("init", errorMessage, error);
           this.updateState({
             status: "error",
-            error:
-              error instanceof Error ? error.message : "Initialization failed",
+            error: errorMessage,
+            consecutiveFailures: this.state.consecutiveFailures + 1,
+            lastErrorTimestamp: new Date().toISOString(),
+            lastErrorContext: "init",
           });
         }),
       ),
@@ -148,14 +156,22 @@ export class SyncManager {
             });
           }),
           Effect.flatMap((response) => {
-            const deviceId = response?.data?.id;
-            if (!deviceId) {
+            // Strict type guard for API response
+            if (
+              !response ||
+              !response.data ||
+              typeof response.data !== "object" ||
+              !response.data.id ||
+              typeof response.data.id !== "string" ||
+              response.data.id.trim() === ""
+            ) {
               return Effect.fail(
                 new DeviceRegistrationError({
-                  message: "Failed to register device: no ID returned",
+                  message: "Failed to register device: invalid or missing ID in response",
                 }),
               );
             }
+            const deviceId = response.data.id;
             return pipe(
               setStorageItem(KEYS.DEVICE_ID, deviceId),
               Effect.map(() => {
@@ -172,9 +188,13 @@ export class SyncManager {
             );
           }),
           Effect.tapError((error) =>
-            Effect.sync(() =>
-              console.error("Device registration failed:", error),
-            ),
+            Effect.sync(() => {
+              const errorMessage =
+                error instanceof Error
+                  ? error.message
+                  : "Device registration failed";
+              this.logStructuredError("device_registration", errorMessage, error);
+            }),
           ),
         );
       }),
@@ -201,17 +221,42 @@ export class SyncManager {
     const syncEffect = pipe(
       checkAuthentication(),
       Effect.flatMap(() => this.sync()),
-      Effect.catchAll((error) =>
+      Effect.catchAll((error: unknown) =>
         Effect.sync(() => {
-          // Silently ignore auth errors
+          // Silently ignore auth errors (user not logged in is expected state)
+          // This allows sync to be called freely without checking auth state first
           if (!(error instanceof AuthenticationError)) {
-            console.error("syncIfAuthenticated error:", error);
+            const errorMessage =
+              error instanceof Error ? error.message : "Sync failed";
+            this.logStructuredError("sync_trigger", errorMessage, error);
           }
         }),
       ),
     );
 
     await Effect.runPromise(syncEffect);
+  };
+
+  /**
+   * Run an authenticated sync and surface any failure to the caller.
+   * Intended for explicit flows such as post-auth setup.
+   */
+  syncAuthenticated = async (): Promise<void> => {
+    if (Platform.OS === "web") {
+      return;
+    }
+
+    if (this.syncInProgress) {
+      this.hasPendingSync = true;
+      return;
+    }
+
+    await Effect.runPromise(
+      pipe(
+        checkAuthentication(),
+        Effect.flatMap(() => this.sync()),
+      ),
+    );
   };
 
   /**
@@ -285,6 +330,9 @@ export class SyncManager {
                 lastPushCount: result.pushCount,
                 lastPullCount: result.pullCount,
                 error: null,
+                consecutiveFailures: 0, // Reset on success
+                lastErrorTimestamp: null,
+                lastErrorContext: null,
               });
             }),
           ),
@@ -294,10 +342,19 @@ export class SyncManager {
         Effect.sync(() => {
           const message =
             error instanceof Error ? error.message : "Sync failed";
-          console.error("Sync error:", message);
+          
           if (!this.syncCancelled && !(error instanceof SyncCancelledError)) {
             this.lastSyncHadError = true;
-            this.updateState({ status: "error", error: message });
+            // Determine context based on current status
+            const context = this.state.status === "pushing" ? "push" : this.state.status === "pulling" ? "pull" : "sync";
+            this.logStructuredError(context, message, error);
+            this.updateState({ 
+              status: "error", 
+              error: message,
+              consecutiveFailures: this.state.consecutiveFailures + 1,
+              lastErrorTimestamp: new Date().toISOString(),
+              lastErrorContext: context,
+            });
           }
         }),
       ),
@@ -403,10 +460,19 @@ export class SyncManager {
             changes,
           }),
           Effect.flatMap((response) => {
-            if (!response?.data) {
+            // Strict type guard for API response
+            if (
+              !response ||
+              !response.data ||
+              typeof response.data !== "object" ||
+              !response.data.counts ||
+              typeof response.data.counts !== "object" ||
+              typeof response.data.counts.upserted !== "number" ||
+              typeof response.data.counts.deleted !== "number"
+            ) {
               return Effect.fail(
                 new SyncPushError({
-                  message: "Push failed: no response data",
+                  message: "Push failed: invalid or missing response data",
                 }),
               );
             }
@@ -417,9 +483,8 @@ export class SyncManager {
           }),
           Effect.catchAll((error) => {
             // Handle 409 Conflict - records already exist on server
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
-            if (errorMessage.includes("(409)")) {
+            const statusCode = getHttpStatusFromError(error);
+            if (statusCode === 409) {
               console.warn(
                 "[Sync Push] 409 conflict: Records already exist on server.",
               );
@@ -451,7 +516,10 @@ export class SyncManager {
         );
       }),
       Effect.tapError((error) =>
-        Effect.sync(() => console.error("Push error:", error)),
+        Effect.sync(() => {
+          const errorMessage = error instanceof Error ? error.message : "Push failed";
+          this.logStructuredError("push", errorMessage, error);
+        }),
       ),
     );
 
@@ -492,37 +560,28 @@ export class SyncManager {
 
   /**
    * Mark all pushed records as synced.
+   * Uses a data-driven approach to reduce duplication.
    */
-  private markAllRecordsSynced = (pushedIds: PushedIds) =>
-    pipe(
-      Effect.all([
-        pushedIds.transactions.length > 0
-          ? markRecordsSyncedForTable(transactions, pushedIds.transactions)
-          : Effect.succeed(undefined),
-        pushedIds.categories.length > 0
-          ? markRecordsSyncedForTable(categories, pushedIds.categories)
-          : Effect.succeed(undefined),
-        pushedIds.products.length > 0
-          ? markRecordsSyncedForTable(products, pushedIds.products)
-          : Effect.succeed(undefined),
-        pushedIds.stores.length > 0
-          ? markRecordsSyncedForTable(stores, pushedIds.stores)
-          : Effect.succeed(undefined),
-        pushedIds.product_listings.length > 0
-          ? markRecordsSyncedForTable(
-              product_listings,
-              pushedIds.product_listings,
-            )
-          : Effect.succeed(undefined),
-        pushedIds.product_listings_history.length > 0
-          ? markRecordsSyncedForTable(
-              product_listings_history,
-              pushedIds.product_listings_history,
-            )
-          : Effect.succeed(undefined),
-      ]),
-      Effect.map(() => undefined),
+  private markAllRecordsSynced = (pushedIds: PushedIds) => {
+    // Define table-to-ids mapping for reduced duplication
+    const tableOperations = [
+      { table: transactions, ids: pushedIds.transactions },
+      { table: categories, ids: pushedIds.categories },
+      { table: products, ids: pushedIds.products },
+      { table: stores, ids: pushedIds.stores },
+      { table: product_listings, ids: pushedIds.product_listings },
+      { table: product_listings_history, ids: pushedIds.product_listings_history },
+    ] as const;
+
+    // Map to effects, only processing tables with IDs
+    const effects = tableOperations.map(({ table, ids }) =>
+      ids.length > 0
+        ? markRecordsSyncedForTable(table, ids)
+        : Effect.succeed(undefined)
     );
+
+    return pipe(Effect.all(effects), Effect.map(() => undefined));
+  };
 
   // ─── Pull ────────────────────────────────────────────────
 
@@ -533,10 +592,19 @@ export class SyncManager {
         lastSyncedAt: this.state.lastSyncedAt,
       }),
       Effect.flatMap((response) => {
-        if (!response?.data) {
+        // Strict type guard for API response
+        if (
+          !response ||
+          !response.data ||
+          typeof response.data !== "object" ||
+          !response.data.syncedAt ||
+          typeof response.data.syncedAt !== "string" ||
+          !response.data.changes ||
+          typeof response.data.changes !== "object"
+        ) {
           return Effect.fail(
             new SyncPullError({
-              message: "Pull failed: no response data",
+              message: "Pull failed: invalid or missing response data",
             }),
           );
         }
@@ -554,7 +622,10 @@ export class SyncManager {
         );
       }),
       Effect.tapError((error) =>
-        Effect.sync(() => console.error("Pull error:", error)),
+        Effect.sync(() => {
+          const errorMessage = error instanceof Error ? error.message : "Pull failed";
+          this.logStructuredError("pull", errorMessage, error);
+        }),
       ),
     );
 
@@ -613,6 +684,33 @@ export class SyncManager {
   private updateState(partial: Partial<SyncState>): void {
     this.state = { ...this.state, ...partial };
     this.notifyListeners();
+  }
+
+  /**
+   * Log structured error with context for better debugging.
+   * Includes timestamp, operation, device ID, and error details.
+   */
+  private logStructuredError(
+    context: string,
+    message: string,
+    error: unknown,
+  ): void {
+    const timestamp = new Date().toISOString();
+    const errorDetails = {
+      timestamp,
+      context,
+      message,
+      deviceId: this.state.deviceId,
+      lastSyncedAt: this.state.lastSyncedAt,
+      consecutiveFailures: this.state.consecutiveFailures + 1,
+      errorType: error instanceof Error ? error.constructor.name : typeof error,
+      stack: error instanceof Error ? error.stack : undefined,
+    };
+
+    console.error(`[SyncManager Error] ${context}:`, message);
+    if (__DEV__) {
+      console.error("Error details:", errorDetails);
+    }
   }
 
   /**
@@ -688,13 +786,17 @@ export class SyncManager {
             error: null,
             lastPushCount: 0,
             lastPullCount: 0,
+            consecutiveFailures: 0,
+            lastErrorTimestamp: null,
+            lastErrorContext: null,
           };
           this.notifyListeners();
         }),
       ),
       Effect.catchAll((error) =>
         Effect.sync(() => {
-          console.error("Reset error:", error);
+          const errorMessage = error instanceof Error ? error.message : "Reset failed";
+          this.logStructuredError("reset", errorMessage, error);
         }),
       ),
     );

--- a/src/services/sync/manager.ts
+++ b/src/services/sync/manager.ts
@@ -187,6 +187,17 @@ export class SyncManager {
    * Safe to call from anywhere — silently no-ops if not logged in.
    */
   syncIfAuthenticated = async (): Promise<void> => {
+    // Early return for web platform
+    if (Platform.OS === "web") {
+      return;
+    }
+
+    // Early return if sync already in progress
+    if (this.syncInProgress) {
+      this.hasPendingSync = true;
+      return;
+    }
+
     const syncEffect = pipe(
       checkAuthentication(),
       Effect.flatMap(() => this.sync()),
@@ -224,33 +235,15 @@ export class SyncManager {
 
   /**
    * Full sync: push local changes, then pull remote changes.
-   * Returns silently if sync is already in progress.
+   * Caller must check if sync is already in progress.
    */
   private sync = () =>
     pipe(
       Effect.sync(() => {
-        // Skip sync for web platform
-        if (Platform.OS === "web") {
-          return false;
-        }
-
-        if (this.syncInProgress) {
-          this.hasPendingSync = true;
-          return false;
-        }
-
         this.syncInProgress = true;
         this.syncCancelled = false;
         this.updateState({ status: "pushing", error: null });
-        return true;
       }),
-      Effect.filterOrFail(
-        (shouldContinue) => shouldContinue,
-        () =>
-          new SyncCancelledError({
-            message: "Sync already in progress or platform unsupported",
-          }),
-      ),
       Effect.flatMap(() => this.ensureDevice()),
       Effect.flatMap((deviceId) =>
         pipe(
@@ -422,6 +415,39 @@ export class SyncManager {
               pushedIds,
             });
           }),
+          Effect.catchAll((error) => {
+            // Handle 409 Conflict - records already exist on server
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            if (errorMessage.includes("(409)")) {
+              console.warn(
+                "[Sync Push] 409 conflict: Records already exist on server.",
+              );
+              console.warn(
+                "[Sync Push] This likely means the app crashed after push succeeded but before marking records as synced.",
+              );
+              console.warn(
+                "[Sync Push] Treating as success and marking local records as synced to resolve conflict.",
+              );
+              if (__DEV__) {
+                console.log(
+                  "[Sync Push] Conflicting record count:",
+                  totalChanges,
+                );
+              }
+              // PRAGMATIC FIX: Records exist on server, so mark them as synced locally
+              // This resolves the infinite retry loop
+              // TODO: Backend should implement UPSERT (INSERT ... ON CONFLICT DO UPDATE)
+              // to handle this gracefully without 409 errors
+              return Effect.succeed({
+                upserted: totalChanges,
+                deleted: 0,
+                pushedIds,
+              });
+            }
+            // Re-throw other errors
+            return Effect.fail(error);
+          }),
         );
       }),
       Effect.tapError((error) =>
@@ -535,9 +561,16 @@ export class SyncManager {
   /**
    * Apply pulled changes to local database.
    * Applies in dependency order to maintain referential integrity.
+   * Must be sequential to respect foreign key constraints:
+   * 1. categories, stores (no dependencies)
+   * 2. products (no dependencies)
+   * 3. transactions (depends on categories)
+   * 4. product_listings (depends on products and stores)
+   * 5. product_listings_history (depends on products)
    */
   private applyRemoteChanges = (changes: SyncChanges) =>
     pipe(
+      // Step 1: Base tables (no dependencies) - can run in parallel
       Effect.all([
         applyTableChanges(
           categories,
@@ -551,19 +584,27 @@ export class SyncManager {
           products,
           changes.products ?? { upserted: [], deleted: [] },
         ),
-        applyTableChanges(
-          transactions,
-          changes.transactions ?? { upserted: [], deleted: [] },
-        ),
-        applyTableChanges(
-          product_listings,
-          changes.productListings ?? { upserted: [], deleted: [] },
-        ),
-        applyTableChanges(
-          product_listings_history,
-          changes.productListingHistory ?? { upserted: [], deleted: [] },
-        ),
       ]),
+      // Step 2: Tables that depend on step 1 - can run in parallel with each other
+      Effect.flatMap((counts1) =>
+        pipe(
+          Effect.all([
+            applyTableChanges(
+              transactions,
+              changes.transactions ?? { upserted: [], deleted: [] },
+            ),
+            applyTableChanges(
+              product_listings,
+              changes.productListings ?? { upserted: [], deleted: [] },
+            ),
+            applyTableChanges(
+              product_listings_history,
+              changes.productListingHistory ?? { upserted: [], deleted: [] },
+            ),
+          ]),
+          Effect.map((counts2) => [...counts1, ...counts2]),
+        ),
+      ),
       Effect.map((counts) => counts.reduce((sum, count) => sum + count, 0)),
     );
 

--- a/src/services/sync/manager.ts
+++ b/src/services/sync/manager.ts
@@ -264,6 +264,15 @@ export class SyncManager {
     );
   };
 
+  getAuthenticatedUserId = async (): Promise<string> => {
+    return Effect.runPromise(
+      pipe(
+        checkAuthentication(),
+        Effect.map((session) => session!.user.id),
+      ),
+    );
+  };
+
   /**
    * Debounced sync — call after local changes.
    * Waits 2 seconds after last call before syncing.

--- a/src/services/sync/types.ts
+++ b/src/services/sync/types.ts
@@ -109,6 +109,10 @@ export interface SyncState {
   error: string | null;
   lastPushCount: number;
   lastPullCount: number;
+  // Retry metadata for diagnosing sync issues
+  consecutiveFailures: number;
+  lastErrorTimestamp: string | null;
+  lastErrorContext: string | null; // e.g., "push", "pull", "init", "device_registration"
 }
 
 // ─── Storage Keys ────────────────────────────────────────────

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,53 @@
+/**
+ * HTTP utility functions for handling HTTP requests and responses.
+ */
+
+/**
+ * Extract HTTP status code from various error formats.
+ *
+ * Handles errors from:
+ * - Direct status property
+ * - Response object with status
+ * - Cause chain with status
+ * - Error messages containing status codes like "(409)"
+ *
+ * @param error - The error object to extract status from
+ * @returns HTTP status code if found, undefined otherwise
+ *
+ * @example
+ * ```ts
+ * const status = getHttpStatusFromError(error);
+ * if (status === 409) {
+ *   // Handle conflict
+ * }
+ * if (status === 401) {
+ *   // Handle unauthorized
+ * }
+ * ```
+ */
+export function getHttpStatusFromError(error: unknown): number | undefined {
+  if (!error) return undefined;
+
+  // Type assertion for property access
+  const e = error as any;
+
+  // Check direct status property
+  if (typeof e.status === "number") return e.status;
+
+  // Check response.status (common in fetch/axios errors)
+  if (typeof e.response?.status === "number") return e.response.status;
+
+  // Check cause chain
+  if (typeof e.cause?.status === "number") return e.cause.status;
+
+  // Fallback: Parse from error message if it contains "(NNN)" format
+  if (typeof e.message === "string") {
+    const match = e.message.match(/\((\d{3})\)/);
+    if (match) {
+      const status = Number.parseInt(match[1], 10);
+      if (!Number.isNaN(status)) return status;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Improve sync robustness by preventing overlapping syncs, handling server-side record conflicts pragmatically, and tightening local upsert and schema behavior to avoid infinite retry loops and data constraint issues.

Bug Fixes:
- Prevent sync from running on unsupported web platform and avoid re-entering sync while a previous sync is in progress.
- Treat 409 conflict responses during push as successful when records already exist on the server, marking local records as synced to break infinite retry loops.
- Ensure numeric fields like amount and price are correctly converted and upserted locally, and avoid resending sync metadata fields to the backend.

Enhancements:
- Apply remote changes in dependency-aware phases to respect foreign key constraints while retaining parallelism where safe.
- Add detailed logging around database upserts and table change failures to aid debugging of sync issues.
- Relax unique constraints on categories and stores by dropping related indexes and schema-level uniqueness, aligning with server behavior and avoiding unnecessary conflicts.

Build:
- Rename and expand npm scripts for Expo workflows and database generation to better reflect their purpose and support prebuild and web targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guided Setup screen and workflow to initialize the app, seed defaults, and gate navigation.
  * New setup state API and a public sync entry to run authenticated syncs.
  * Added a utility to clear local app data.

* **Bug Fixes**
  * Improved sync error handling, diagnostics, and conflict handling to prevent infinite retries.

* **Refactor**
  * Relaxed uniqueness constraints on category and store data.

* **Chores**
  * Updated project scripts for development and DB generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Guide signed-in users through setup before opening the app**

### What Changed
- After sign-in or sign-up, users now go to a setup screen instead of entering the app immediately.
- Setup shows progress, retries failed setup, and blocks entry until account registration and initial data sync finish.
- The old “Skip for now” path was removed, so new accounts always complete setup first.
- Sync now treats server conflict responses as success when the record already exists, which stops the same changes from being retried.
- Category and store names no longer enforce the previous uniqueness rules, reducing conflicts when syncing data.

### Impact
`✅ Fewer first-login dead ends`
`✅ Fewer sync retry loops`
`✅ Fewer data conflict errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
